### PR TITLE
wm.c: fix invalid read error

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -2226,6 +2226,8 @@ int main(int argc, char *argv[])
 
 	register_event_handlers();
 	register_ipc_handlers();
+	load_defaults();
+
 	if (setup() < 0)
 		errx(EXIT_FAILURE, "error connecting to X");
 	/* if not set, get path of the rc file */
@@ -2238,7 +2240,6 @@ int main(int argc, char *argv[])
 					__NAME__, __CONFIG_NAME__);
 	}
 	/* execute config file */
-	load_defaults();
 	load_config(config_path);
 	run();
 


### PR DESCRIPTION
setup() would malloc based upon the size of conf.groups, which
would be 0 as load_defaults() hadn't been called yet. As a result,
change_nr_of_groups() (at line 1350) would cause an invalid
read of size 1 as group_in_use has size 0.
