### PR TITLE
fix monocle window height using wrong gap variables

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -1010,7 +1010,7 @@ monocle_window(struct client *client, int16_t mon_x, int16_t mon_y, uint16_t mon
 	client->geom.width = mon_width - 2 * conf.border_width
 		- conf.gap_left - conf.gap_right;
 	client->geom.height = mon_height - 2 * conf.border_width
-		- conf.gap_left - conf.gap_right;
+		- conf.gap_up - conf.gap_down;
 	teleport_window(client->window, client->geom.x, client->geom.y);
 	resize_window_absolute(client->window, client->geom.width, client->geom.height);
 	client->monocled = true;


### PR DESCRIPTION
Current monocle window uses gap_left and gap_right for window height calculation, should use gap_up and gap_down instead.
This causes problems when users specify different gaps on each side.
Probably went unnoticed if each gaps are equal.
