### PR TITLE
Add grid movement and resizing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## To be: v0.5.0
+## v0.5.0
 
 * [window_put_in_grid now has two additional params to specify how many cells to
 	occupy](https://github.com/tudurom/windowchef/issues/52). This is not
@@ -8,3 +8,6 @@
 * Each window managed by the WM has a property named `WINDOWCHEF_STATUS` that
 	contains data about it. It is updated every time the data is updated, such
 	as when you move or resize the window. JSON format.
+* Windows can be focused by others (_NET_ACTIVE_WINDOW)
+* Windowchef respects chwbb, again. (#51)
+* Borders render correctly in some programs (#49)

--- a/client.c
+++ b/client.c
@@ -64,6 +64,8 @@ static struct Command c[] = {
 	{ "window_monocle"            , IPCWindowMonocle         ,  0 , NULL        } ,
 	{ "window_close"              , IPCWindowClose           ,  0 , NULL        } ,
 	{ "window_put_in_grid"        , IPCWindowPutInGrid       ,  6 , fn_hack     } ,
+	{ "window_move_in_grid"       , IPCWindowMoveInGrid      ,  2 , fn_offset   } ,
+	{ "window_resize_in_grid"     , IPCWindowResizeInGrid    ,  2 , fn_offset   } ,
 	{ "window_snap"               , IPCWindowSnap            ,  1 , fn_position } ,
 	{ "window_cycle"              , IPCWindowCycle           ,  0 , NULL        } ,
 	{ "window_rev_cycle"          , IPCWindowRevCycle        ,  0 , NULL        } ,

--- a/ipc.h
+++ b/ipc.h
@@ -21,6 +21,8 @@ enum IPCCommand {
 	IPCWindowMonocle,
 	IPCWindowClose,
 	IPCWindowPutInGrid,
+	IPCWindowMoveInGrid,
+	IPCWindowResizeInGrid,
 	IPCWindowSnap,
 	IPCWindowCycle,
 	IPCWindowRevCycle,

--- a/man/waitron.1
+++ b/man/waitron.1
@@ -101,6 +101,14 @@ Closes the focused window\.
 Moves and resizes the focused windows accordingly to fit in a cell defined by the \fIcell_x\fR and \fIcell_y\fR coordinates, measuring \fIcell_width\fR in width and \fIcell_height\fR in height, in a virtual grid with width \fIgrid_width\fR and height \fIgrid_height\fR on the current monitor\. \fIcell_width\fR and \fIcell_height\fR are expressed in grid cells\. Gaps around the windows in the grid can be added along with monitor gaps\.
 .
 .TP
+\fBwindow_move_in_grid\fR \fIx\fR \fIy\fR
+Move a gridded window by \fIx\fR and \fIy\fR grid spaces.
+.
+.TP
+\fBwindow_resize_in_grid\fR \fIx\fR \fIy\fR
+Resize a gridded window by \fIx\fR and \fIy\fR grid spaces.
+.
+.TP
 \fBwindow_snap\fR \fIPOSITION\fR
 Snap the window on the screen in a position defined by \fIPOSITION\fR\.
 .

--- a/man/waitron.1.html
+++ b/man/waitron.1.html
@@ -137,6 +137,8 @@ anything on <code>stdout</code>.</p>
   <var>grid_width</var> and height <var>grid_height</var> on the current monitor.
   <var>cell_width</var> and <var>cell_height</var> are expressed in grid cells.
   Gaps around the windows in the grid can be added along with monitor gaps.</p></dd>
+<dt><code>window_move_in_grid</code> <var>x</var> <var>y</var></dt><dd><p> Move a gridded window by <var>x</var> and <var>y</var> grid spaces.</p></dd>
+<dt><code>window_resize_in_grid</code> <var>x</var> <var>y</var></dt><dd><p> Resize a gridded window by <var>x</var> and <var>y</var> grid spaces.</p></dd>
 <dt><code>window_snap</code> <var>POSITION</var></dt><dd><p>  Snap the window on the screen in a position defined by <var>POSITION</var>.</p></dd>
 <dt><code>window_cycle</code></dt><dd><p>  Cycle through mapped windows.</p></dd>
 <dt><code>window_rev_cycle</code></dt><dd><p>  Reverse cycle through mapped windows.</p></dd>

--- a/man/waitron.1.md
+++ b/man/waitron.1.md
@@ -90,6 +90,12 @@ anything on `stdout`.
 	<cell_width> and <cell_height> are expressed in grid cells.
 	Gaps around the windows in the grid can be added along with monitor gaps.
 
+* `window_move_in_grid` <x> <y>:
+        Move a gridded window by <x> and <y> grid spaces.
+
+* `window_resize_in_grid` <x> <y>:
+        Resize a gridded window by <x> and <y> grid spaces.
+
 * `window_snap` <POSITION>:
 	Snap the window on the screen in a position defined by <POSITION>.
 

--- a/types.h
+++ b/types.h
@@ -76,6 +76,7 @@ struct client {
 	uint16_t width_inc, height_inc;
 	bool mapped;
 	uint32_t group;
+	uint8_t depth;
 };
 
 struct monitor {

--- a/types.h
+++ b/types.h
@@ -63,11 +63,18 @@ struct window_geom {
 	bool set_by_user;
 };
 
+struct grid {
+	int16_t gx, gy;
+	int16_t px, py;
+	int16_t sx, sy;
+};
+
 struct client {
 	xcb_window_t window;
 	struct window_geom geom;
 	struct window_geom orig_geom;
-	bool maxed, hmaxed, vmaxed, monocled;
+	struct grid grid;
+	bool maxed, hmaxed, vmaxed, monocled, gridded;
 	struct list_item *item;
 	struct list_item *focus_item;
 	struct monitor *monitor;

--- a/wm.c
+++ b/wm.c
@@ -2781,7 +2781,7 @@ ipc_window_move(uint32_t *d)
 
 	x = d[2];
 	y = d[3];
-if (d[0])
+	if (d[0])
 		x = -x;
 	if (d[1])
 		y = -y;

--- a/wm.c
+++ b/wm.c
@@ -2961,9 +2961,10 @@ ipc_window_unmaximize(uint32_t *d)
 	if (focused_win == NULL)
 		return;
 
-	unmaximize_window(focused_win);
-
-	set_focused(focused_win);
+	if (is_special(focused_win)) {
+		reset_window(focused_win);
+		set_focused(focused_win);
+	}
 
 	xcb_flush(conn);
 }

--- a/wm.c
+++ b/wm.c
@@ -3620,11 +3620,14 @@ load_defaults(void)
 static void
 load_config(char *config_path)
 {
-	if (fork() == 0) {
+	int f = fork();
+	if (f == 0) {
 		setsid();
 		DMSG("loading %s\n", config_path);
 		execl(config_path, config_path, NULL);
-		errx(EXIT_FAILURE, "couldn't load config file");
+		err(EXIT_FAILURE, "couldn't load config file");
+	} else if (f == -1) {
+		err(EXIT_FAILURE, NULL);
 	}
 }
 


### PR DESCRIPTION
I would like to reopen PR #57. 

It has been a year since I closed the original PR since the two grid-based operations I proposed could be implemented outside of windowchef with the help of wmutils, and it seemed good enough for me at the time.

After a year of using different window managers, namely windowchef, mwm (my fork of windowchef), fvwm, wmutils, cwm, awesome, qtile and bspwm, I am still struggling to settle on a wm for good mainly because none of these wms have grid operations baked-in by default. I considered several other options before opening this PR:

- I could continue to maintain and use my windowchef fork, but I'd rather use and contribute to windowchef directly than working on a wm that only I am going to use.
- I could also go the wmutils way as I did at first, but I would rather not have additional dependencies and depend on a shell script that is going to be approximately the same size as this PR (doc excluded).
- I could go the program-your-own-wm route with awesome, but it lacks orthogonality and is somewhat contrived to setup.

Since neither of these options seem to cut it, I would like to merge these two functions to windowchef's core. I have other cool grid operations in mind that could be easily be implemented if this PR is merged (notably increasing and decreasing grid size on all four sides simultaneously).

Of course I would like to know what other windowchef users think of these changes and if they would be interested in using these kind of operations. If no one is really interested I think I will stick with maintaining my own branch.